### PR TITLE
Updated doPost() in MessageServerlet.java

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,9 +76,13 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    Message message = new Message(user, text);
+    String regex = "(https?://\\S+\\.(png|jpg))";
+    String replacement = "<img src = \"$1\" />";
+    String textWithImagesReplaced = userText.replaceAll(regex, replacement);
+
+    Message message = new Message(user, textWithImagesReplaced);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);


### PR DESCRIPTION
I have tweaked this function in order to display a picture in the message log when an image url is written in the message.

The following occurs on the input "here is an image https://ichef.bbci.co.uk/news/660/cpsprodpb/37B5/production/_89716241_thinkstockphotos-523060154.jpg"

<img width="769" alt="Capture" src="https://user-images.githubusercontent.com/37260247/59006812-ac9a7480-87d8-11e9-8929-9e95d703acfa.PNG">

Note that the image does not resize to fit the table properly yet, this functionality has yet to be implemented.
