### PR TITLE
Updated user-page.css

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,9 +76,13 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    Message message = new Message(user, text);
+    String regex = "(https?://\\S+\\.(png|jpg))";
+    String replacement = "<img src = \"$1\" />";
+    String textWithImagesReplaced = userText.replaceAll(regex, replacement);
+
+    Message message = new Message(user, textWithImagesReplaced);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -45,3 +45,11 @@
 .hidden {
   display: none;
 }
+
+/* This formats the any image on the user-page to 
+   fit within the container. */
+.message-body img {
+  display: block;
+  margin-top:25px;
+  max-width: 75%;
+}


### PR DESCRIPTION
This fixes the formatting of images on the user's page, by doing the following:
Makes images a block display, so it shows up below text instead of next to it), 
Gives images a top margin of 25 pixels 
Gives images a maximum width of 75% of its parent container
A sample of the update is shown in the pictures attached

Before:
<img width="451" alt="Capture" src="https://user-images.githubusercontent.com/37260247/59078610-cbf6d780-8894-11e9-9651-c7f0ffcf7274.PNG">

After:
<img width="390" alt="Capture2" src="https://user-images.githubusercontent.com/37260247/59078615-d0bb8b80-8894-11e9-9545-08ba9cb33bc6.PNG">


.